### PR TITLE
Pin SIMD version; Add rust linter CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,4 +14,5 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: --all-features --all-targets --manifest-path RustVersion/Cargo.toml -- -D warnings
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,6 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
-      - uses: Swatinem/rust-cache@v1
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,17 @@
+on: push
+name: Clippy check
+jobs:
+  
+  cargo-clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Check Clippy Linter
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: nightly
+          components: rustfmt, clippy
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,8 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: rustfmt, clippy
+      - name: Set toolchain
+        run: rustup default nightly
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
       - uses: Swatinem/rust-cache@v1
       - name: Check Clippy Linter
         uses: actions-rs/cargo@v1

--- a/RustVersion/src/kd_tree.rs
+++ b/RustVersion/src/kd_tree.rs
@@ -1,6 +1,6 @@
-use std::{fs::File, io::Write, time::Instant};
+use std::{fs::File, io::Write};
 
-use core_simd::*;
+use core_simd::simd::*;
 
 use crate::simd_particle::*;
 
@@ -179,7 +179,7 @@ pub fn simple_sim(bodies: &mut Vec<Particle>, dt: f64, steps: i64) {
     let mut tree = allocate_node_vec(bodies.len());
     let mut indices: Vec<usize> = (0..bodies.len()).collect();
 
-    for step in 0..steps {
+    for _ in 0..steps {
         // if step % 100 == 0 {
         //     let elapsed_secs = time.elapsed().as_nanos() as f64 / 1e9;
         //     println!("Step = {}, duration = {}, n = {}, nodes = {}", step, elapsed_secs, bodies.len(), tree.len());
@@ -204,6 +204,7 @@ pub fn simple_sim(bodies: &mut Vec<Particle>, dt: f64, steps: i64) {
     }
 }
 
+#[allow(dead_code)]
 fn print_tree(step: i64, tree: &Vec<KDTree>, particles: &Vec<Particle>) -> std::io::Result<()> {
     let mut file = File::create(format!("tree{}.txt", step))?;
 
@@ -229,6 +230,7 @@ fn print_tree(step: i64, tree: &Vec<KDTree>, particles: &Vec<Particle>) -> std::
     Ok(())
 }
 
+#[allow(dead_code)]
 fn recur_test_tree_struct(
     node: usize,
     nodes: &Vec<KDTree>,
@@ -274,7 +276,7 @@ fn recur_test_tree_struct(
 #[cfg(test)]
 mod tests {
     use crate::{kd_tree, simd_particle};
-    use core_simd::*;
+    use core_simd::simd::*;
 
     #[test]
     fn single_node() {

--- a/RustVersion/src/simd_particle.rs
+++ b/RustVersion/src/simd_particle.rs
@@ -9,24 +9,24 @@ pub struct Particle {
 
 #[allow(dead_code)]
 pub fn two_bodies() -> Vec<Particle> {
-    let mut bodies = Vec::new();
-    bodies.push(Particle {
-        p: f64x4::splat(0.0),
-        v: f64x4::splat(0.0),
-        r: 1.0,
-        m: 1.0,
-    });
-    bodies.push(Particle {
-        p: f64x4::from_array([1.0, 0.0, 0.0, 0.0]),
-        v: f64x4::from_array([0.0, 1.0, 0.0, 0.0]),
-        r: 1e-4,
-        m: 1e-20,
-    });
-    bodies
+    vec![
+        Particle {
+            p: f64x4::splat(0.0),
+            v: f64x4::splat(0.0),
+            r: 1.0,
+            m: 1.0,
+        },
+        Particle {
+            p: f64x4::from_array([1.0, 0.0, 0.0, 0.0]),
+            v: f64x4::from_array([0.0, 1.0, 0.0, 0.0]),
+            r: 1e-4,
+            m: 1e-20,
+        },
+    ]
 }
 
 pub fn circular_orbits(n: usize) -> Vec<Particle> {
-    let mut particle_buf = vec![];
+    let mut particle_buf = Vec::with_capacity(n + 1);
     particle_buf.push(Particle {
         p: f64x4::splat(0.0),
         v: f64x4::splat(0.0),
@@ -37,7 +37,7 @@ pub fn circular_orbits(n: usize) -> Vec<Particle> {
     for i in 0..n {
         let d = 0.1 + ((i as f64) * 5.0 / (n as f64));
         let v = f64::sqrt(1.0 / d);
-        let theta = fastrand::f64() * 6.28;
+        let theta = fastrand::f64() * std::f64::consts::TAU;
         let x = d * f64::cos(theta);
         let y = d * f64::sin(theta);
         let vx = -v * f64::sin(theta);
@@ -92,7 +92,7 @@ pub fn distance(x1: f64x4, x2: f64x4) -> f64 {
     f64::sqrt(distance_sqr(x1, x2))
 }
 
-fn calc_accel(i: usize, j: usize, pi: &Particle, pj: &Particle, acc: &mut Vec<f64x4>) {
+fn calc_accel(i: usize, j: usize, pi: &Particle, pj: &Particle, acc: &mut [f64x4]) {
     let dp = pi.p - pj.p;
     let dp2 = dp * dp;
     let dist = f64::sqrt(dp2.reduce_sum());

--- a/RustVersion/src/simd_particle.rs
+++ b/RustVersion/src/simd_particle.rs
@@ -1,29 +1,37 @@
-
-use core_simd::*;
+use core_simd::simd::*;
 
 pub struct Particle {
-  pub p: f64x4,
-  pub v: f64x4,
-  pub r: f64,
-  pub m: f64
+    pub p: f64x4,
+    pub v: f64x4,
+    pub r: f64,
+    pub m: f64,
 }
 
+#[allow(dead_code)]
 pub fn two_bodies() -> Vec<Particle> {
-  let mut bodies = Vec::new();
-  bodies.push(Particle { p: f64x4::splat(0.0), 
-                         v: f64x4::splat(0.0), r: 1.0, m: 1.0 });
-  bodies.push(Particle { p: f64x4::from_array([1.0, 0.0, 0.0, 0.0]), 
-                         v: f64x4::from_array([0.0, 1.0, 0.0, 0.0]), r: 1e-4, m: 1e-20 });
-  bodies
+    let mut bodies = Vec::new();
+    bodies.push(Particle {
+        p: f64x4::splat(0.0),
+        v: f64x4::splat(0.0),
+        r: 1.0,
+        m: 1.0,
+    });
+    bodies.push(Particle {
+        p: f64x4::from_array([1.0, 0.0, 0.0, 0.0]),
+        v: f64x4::from_array([0.0, 1.0, 0.0, 0.0]),
+        r: 1e-4,
+        m: 1e-20,
+    });
+    bodies
 }
 
 pub fn circular_orbits(n: usize) -> Vec<Particle> {
-  let mut particle_buf = vec![];
+    let mut particle_buf = vec![];
     particle_buf.push(Particle {
-      p: f64x4::splat(0.0),
-      v: f64x4::splat(0.0),
-      r: 0.00465047,
-      m: 1.0,
+        p: f64x4::splat(0.0),
+        v: f64x4::splat(0.0),
+        r: 0.00465047,
+        m: 1.0,
     });
 
     for i in 0..n {
@@ -44,63 +52,70 @@ pub fn circular_orbits(n: usize) -> Vec<Particle> {
     particle_buf
 }
 
+#[allow(dead_code)]
 pub fn simple_sim(mut bodies: Vec<Particle>, dt: f64) {
-  let dt_vec = f64x4::splat(dt);
-  let mut acc = Vec::new();
-  for _ in 0..bodies.len() { 
-      acc.push(f64x4::splat(0.0))
-  };
-  for step in 1..1000001 {
-      for i in 0..bodies.len()-1 {
-          for j in i+1..bodies.len() {
-              calc_accel(i, j, &bodies[i], &bodies[j], &mut acc);
-          }
-      }
-      for i in 0..bodies.len() { 
-          bodies[i].v += dt_vec * acc[i];
-          let dp = dt_vec * bodies[i].v;
-          bodies[i].p += dp;
-          acc[i] = f64x4::splat(0.0);
-      }
-      if step % 10000 == 0 {
-          println!("{} {} {} {} {}", step, bodies[1].p[0], bodies[1].p[1], bodies[1].v[0], bodies[1].v[1]);
-      }
-  }
+    let dt_vec = f64x4::splat(dt);
+    let mut acc = Vec::new();
+    for _ in 0..bodies.len() {
+        acc.push(f64x4::splat(0.0))
+    }
+    for step in 1..1000001 {
+        for i in 0..bodies.len() - 1 {
+            for j in i + 1..bodies.len() {
+                calc_accel(i, j, &bodies[i], &bodies[j], &mut acc);
+            }
+        }
+        for i in 0..bodies.len() {
+            bodies[i].v += dt_vec * acc[i];
+            let dp = dt_vec * bodies[i].v;
+            bodies[i].p += dp;
+            acc[i] = f64x4::splat(0.0);
+        }
+        if step % 10000 == 0 {
+            println!(
+                "{} {} {} {} {}",
+                step, bodies[1].p[0], bodies[1].p[1], bodies[1].v[0], bodies[1].v[1]
+            );
+        }
+    }
 }
 
+#[allow(dead_code)]
 pub fn distance_sqr(x1: f64x4, x2: f64x4) -> f64 {
-  let dp = x1 - x2;
-  let dp2 = dp * dp;
-  dp2.reduce_sum()
+    let dp = x1 - x2;
+    let dp2 = dp * dp;
+    dp2.reduce_sum()
 }
 
+#[allow(dead_code)]
 pub fn distance(x1: f64x4, x2: f64x4) -> f64 {
-  f64::sqrt(distance_sqr(x1, x2))
+    f64::sqrt(distance_sqr(x1, x2))
 }
 
 fn calc_accel(i: usize, j: usize, pi: &Particle, pj: &Particle, acc: &mut Vec<f64x4>) {
-  let dp = pi.p - pj.p;
-  let dp2 = dp * dp;
-  let dist = f64::sqrt(dp2.reduce_sum());
-  let magi = f64x4::splat(-pj.m / (dist*dist*dist));
-  acc[i] += dp * magi;
-  let magj = f64x4::splat(pi.m / (dist*dist*dist));
-  acc[j] += dp * magj;
+    let dp = pi.p - pj.p;
+    let dp2 = dp * dp;
+    let dist = f64::sqrt(dp2.reduce_sum());
+    let magi = f64x4::splat(-pj.m / (dist * dist * dist));
+    acc[i] += dp * magi;
+    let magj = f64x4::splat(pi.m / (dist * dist * dist));
+    acc[j] += dp * magj;
 }
 
 pub fn calc_pp_accel(pi: &Particle, pj: &Particle) -> f64x4 {
-  let dp = pi.p - pj.p;
-  let dp2 = dp * dp;
-  let dist = f64::sqrt(dp2.reduce_sum());
-  let magi = f64x4::splat(-pj.m / (dist*dist*dist));
-//   println!("magi={}", magi[0]);
-  dp * magi
+    let dp = pi.p - pj.p;
+    let dp2 = dp * dp;
+    let dist = f64::sqrt(dp2.reduce_sum());
+    let magi = f64x4::splat(-pj.m / (dist * dist * dist));
+    //   println!("magi={}", magi[0]);
+    dp * magi
 }
 
+#[allow(dead_code)]
 pub fn calc_cm_accel(pi: &Particle, m: f64, cm: f64x4) -> f64x4 {
-  let dp = pi.p - cm;
-  let dp2 = dp * dp;
-  let dist = f64::sqrt(dp2.reduce_sum());
-  let magi = f64x4::splat(-m / (dist*dist*dist));
-  dp * magi
+    let dp = pi.p - cm;
+    let dp2 = dp * dp;
+    let dist = f64::sqrt(dp2.reduce_sum());
+    let magi = f64x4::splat(-m / (dist * dist * dist));
+    dp * magi
 }


### PR DESCRIPTION
The SIMD dependency was unversioned. A breaking change was pushed and the imports in this project broke.

This PR pins that dependency to a specific commit SHA, adds a rust linter to the CI, and fixes the imports. And runs the formatter.